### PR TITLE
Gulp build suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ To install the dependencies required by the build suite, you will need to naviga
     
 
 #### Run 'gulp' to start the build suite.
-Once this process has successfully completed, you will be able to run the following command. 
+If you haven't installed gulp before, you will need to install the gulp-cli tool. If you already have gulp-cli installed (you can verify with 'gulp -v' and check for 'CLI version'), you can safely skip this command.
+
+    npm install --global gulp-cli
+    
+You will then be able to run the following command. 
 
     gulp
     

--- a/README.md
+++ b/README.md
@@ -1,29 +1,49 @@
-<br><br>
 <h1 align="center"> Legacy Framework 4.0 </h1>
 <h3 align="center"> modern design, lightweight framework </h3>
-<br><br>
-<br />
+
+<br><br><br>
 
 #### What's in the download?
 
-If you want to download Legacy, you don't get the dev kit (SASS files/compilers)
-<br />
-If you'd like to get all of this, download the repo zip instead.
+The download contains just what's in the repo:
 
 ```
-
-Legacy/
-├── Hello.html
+LegacyFramework
 ├── LICENSE
-├── legacy.min.css
-└── legacy.css
-
+├── README.md
+├── dist
+│   ├── legacy.css
+│   └── legacy.min.css
+├── index.html
+└── src
+    ├── legacy.sass
+    └── partials
+        ├── legacybuttons.sass
+        ├── legacycolors.sass
+        ├── legacyforms.sass
+        ├── legacygrid.sass
+        ├── legacynavbar.sass
+        ├── legacyother.sass
+        ├── legacyreset.sass
+        ├── legacysetup.sass
+        ├── legacytables.sass
+        ├── legacytypography.sass
+        └── legacyutilities.sass
 ```
 
+<br><br><br>
 
-<br>
+#### Want us to host it?
 
-## How To Build Legacy From Source
+To use Legacy on your site without downloading it, include this code in your head tags:
+
+    <link href="https://cdn.joexn.io/legacy.css" rel="stylesheet">
+
+<br><br><br>
+
+
+
+### How To Build Legacy From Source
 
 Included in the repo is a build system to help you build and modify Legacy. 
 
@@ -49,28 +69,30 @@ You will then be able to run the following command.
 
     gulp
     
-Gulp is a modern streaming build system that will compile the Legacy sass files into workable css. In addition, it will monitor changes to the source and automatically reprocess the source - so changes are shown immediately. Also included in the build suite is browsersync. Browsersync is a tool that will automatically inject any changes into your browser - providing almost instant feedback for any changes.  
+Gulp is a modern streaming build system that will compile the Legacy sass files into workable css. In addition, it will monitor changes and automatically reprocess the source - so changes are reflected in the dist folder immediately. 
 
-##
+##### Using BrowserSync for development
+Also included in the build suite is browsersync. Browsersync is a tool that will automatically inject changes to Legacy into any open and connected browser, providing instant visual feedback for any changes. To run gulp with browsersync, you can run the following command:
 
-#### Want us to host it?
-To use Legacy on your site without downloading it, include this code in your head tags:
+    gulp serve 
 
-```
-<link href="https://cdn.joexn.io/legacy.css" rel="stylesheet">
-```
 
-<br /><br /><br />
+<br><br><br>
 
 <center>[designed and developed by joexn :ok_hand:](https://joexn.com)</center>
 
-<hr>
+- - -
 
-  <h3>check out these guys</h3>
-    <p>All the people listed below have helped shape Legacy into the framework it is today.<br />
-    <small>(you will only be listed here if you have helped more than once with Legacy's development)</small>
-    </p>
-    <a href="https://github.com/nloveladyallen">/nloveladyallen</a><br>
-    <a href="https://github.com/georgejenkins">/georgejenkins</a><br>
-    <a href="https://github.com/runofthemill">/runofthemill</a><br>
-    <a href="https://github.com/nishad">/nishad</a><br>
+<br><br><br>
+
+### check out these guys
+
+
+All the people listed below have helped shape Legacy into the framework it is today.
+<small>(you will only be listed here if you have helped more than once with Legacy's development)</small>
+
+[/nloveladyallen](https://github.com/nloveladyallen)
+
+[/georgejenkins](https://github.com/georgejenkins)
+
+[/Haroenv](https://github.com/Haroenv)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <h3 align="center"> modern design, lightweight framework </h3>
 <br><br>
 <br />
+
 #### What's in the download?
 
 If you want to download Legacy, you don't get the dev kit (SASS files/compilers)
@@ -19,28 +20,35 @@ Legacy/
 
 ```
 
-<br /><br /><br />
-#### How to install, compress and minify.
 
-I use [Atom](https://atom.io) to code SASS, then a ```.command``` file to automatically compile and minify the files for me. <br /><br />
- Prefer a more traditional method? Use the instructions below.
+<br>
 
-Install SASS using if you haven't already:
+## How To Build Legacy From Source
 
-    gem install sass
+Included in the repo is a build system to help you build and modify Legacy. 
 
-(Depending on your setup, this may or may not require `sudo`.)
+#### Ensure you have nodejs installed.
+To utilise the project build suite, you will need to have nodejs installed on your system. You can verify you have node installed by using the command:
 
-To compile the SASS source code to CSS, use:
+    node -v
 
-    sass legacy-core.sass legacy.css
+If you see the the version number, you are ready to proceed. If not, you will have to ensure you both have node installed and it is configured in your system's path. 
 
-To compile the SASS source to a minified file, use:
+#### Run 'npm install' to resolve dependencies.
+To install the dependencies required by the build suite, you will need to navigate to the folder containing the 'package.json' file. By running the following command, you will invoke the node package manager (npm) to download the dependencies described in the package.json file. 
 
-    sass -t compressed legacy.sass legacy.min.css
+    npm install
+    
 
+#### Run 'gulp' to start the build suite.
+Once this process has successfully completed, you will be able to run the following command. 
 
-<br /><br /><br />
+    gulp
+    
+Gulp is a modern streaming build system that will compile the Legacy sass files into workable css. In addition, it will monitor changes to the source and automatically reprocess the source - so changes are shown immediately. Also included in the build suite is browsersync. Browsersync is a tool that will automatically inject any changes into your browser - providing almost instant feedback for any changes.  
+
+##
+
 #### Want us to host it?
 To use Legacy on your site without downloading it, include this code in your head tags:
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,39 +1,46 @@
-var gulp = require('gulp');
-var sass = require('gulp-sass');
-var rename = require('gulp-rename');
-var cleanCSS = require('gulp-clean-css');
-var autoprefixer = require('gulp-autoprefixer');
-var browserSync = require('browser-sync').create();
+var gulp = require("gulp");
+var sass = require("gulp-sass");
+var rename = require("gulp-rename");
+var autoprefixer = require("gulp-autoprefixer");
+var browserSync = require("browser-sync").create();
 
-gulp.task('default', ['serve']);
+gulp.task("default", ["minify-css", "sass-watch"]);
 
-gulp.task('serve', ['minify-css'], function() {
-  browserSync.init({
-    server: {
-      baseDir: "./"
-    }
-  });
-  
-  gulp.watch("./src/**/*.sass", ['sass']);
+gulp.task("serve", ["launch-browsersync", "default"]);
+
+gulp.task("sass-watch", function() {
+  gulp.watch("src/**/*.sass", ["minify-css"]);
+  setTimeout(function () {
+    console.log("Watching for changes...");
+    console.log("To abort, press ^C");
+  }, 500);
 });
 
-gulp.task('sass', function() {
+gulp.task("process-sass", function() {
   return gulp.src("./src/legacy.sass")
-  .pipe(sass())
-  .on('error', onError)
-  .pipe(autoprefixer())
-  .pipe(gulp.dest("./dist/"));
+    .pipe(sass())
+    .on("error", onError)
+    .pipe(autoprefixer())
+    .pipe(gulp.dest("./dist/"))
+    .pipe(browserSync.stream());
 });
 
-gulp.task('minify-css', ['sass'], function() {
-  return gulp.src("./dist/legacy.css")
-  .pipe(cleanCSS({compatibility: 'ie8'}))
-  .pipe(rename({suffix: '.min'}))
-  .pipe(gulp.dest("./dist/"))	
-  .pipe(browserSync.stream());
+gulp.task("minify-css", ["process-sass"], function() {
+  return gulp.src("./src/legacy.sass")
+    .pipe(sass({outputStyle: "compressed"}))
+    .on("error", onError)
+    .pipe(autoprefixer())
+    .pipe(rename({suffix: ".min"}))
+    .pipe(gulp.dest("./dist/"));
 });
 
 function onError(err) {
-  console.log(err);
-  this.emit('end');
+  console.error(err);
+  this.emit("end");
 }
+
+gulp.task("launch-browsersync", function() {
+  browserSync.init({
+    server: true
+  });
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,33 +7,30 @@ var browserSync = require('browser-sync').create();
 
 gulp.task('default', ['serve']);
 
-// Static Server + watching sass/html files
 gulp.task('serve', ['minify-css'], function() {
-
-    browserSync.init({
-        server: {
-            baseDir: "./"
-        }
-    });
-
-    gulp.watch("./src/**/*.sass", ['sass']); //If any sass changes, then process them
+  browserSync.init({
+    server: {
+      baseDir: "./"
+    }
+  });
+  
+  gulp.watch("./src/**/*.sass", ['sass']);
 });
 
 gulp.task('sass', function() {
-    return gulp.src("./src/legacy.sass") 		//Grab the top level sass files
-        .pipe(sass())					//Process them into CSS
-        .on('error', onError)			//Print error if one occurs
-        .pipe(autoprefixer())			//Prefix all necessary items
-        .pipe(gulp.dest("./dist/"))	;	//Pipe to file
-
+  return gulp.src("./src/legacy.sass")
+  .pipe(sass())
+  .on('error', onError)
+  .pipe(autoprefixer())
+  .pipe(gulp.dest("./dist/"));
 });
 
 gulp.task('minify-css', ['sass'], function() {
-	return gulp.src("./dist/legacy.css")
-	.pipe(cleanCSS({compatibility: 'ie8'}))
-	.pipe(rename({suffix: '.min'}))
-	.pipe(gulp.dest("./dist/"))	
-    .pipe(browserSync.stream());	//Stream changes to all browsers
+  return gulp.src("./dist/legacy.css")
+  .pipe(cleanCSS({compatibility: 'ie8'}))
+  .pipe(rename({suffix: '.min'}))
+  .pipe(gulp.dest("./dist/"))	
+  .pipe(browserSync.stream());
 });
 
 function onError(err) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,42 @@
+var gulp = require('gulp');
+var sass = require('gulp-sass');
+var rename = require('gulp-rename');
+var cleanCSS = require('gulp-clean-css');
+var autoprefixer = require('gulp-autoprefixer');
+var browserSync = require('browser-sync').create();
+
+gulp.task('default', ['serve']);
+
+// Static Server + watching sass/html files
+gulp.task('serve', ['minify-css'], function() {
+
+    browserSync.init({
+        server: {
+            baseDir: "./"
+        }
+    });
+
+    gulp.watch("./src/**/*.sass", ['sass']); //If any sass changes, then process them
+});
+
+gulp.task('sass', function() {
+    return gulp.src("./src/legacy.sass") 		//Grab the top level sass files
+        .pipe(sass())					//Process them into CSS
+        .on('error', onError)			//Print error if one occurs
+        .pipe(autoprefixer())			//Prefix all necessary items
+        .pipe(gulp.dest("./dist/"))	;	//Pipe to file
+
+});
+
+gulp.task('minify-css', ['sass'], function() {
+	return gulp.src("./dist/legacy.css")
+	.pipe(cleanCSS({compatibility: 'ie8'}))
+	.pipe(rename({suffix: '.min'}))
+	.pipe(gulp.dest("./dist/"))	
+    .pipe(browserSync.stream());	//Stream changes to all browsers
+});
+
+function onError(err) {
+  console.log(err);
+  this.emit('end');
+}

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ joexn.io
   <META NAME="Description" CONTENT="The getting started page for the Legacy Framework. This page contains the code you need to get started creating your own website.">
   <META NAME="Keywords" CONTENT="Legacy, Framework, Getting, Started, joexn, LegacyFramework.com">
   <META NAME="Robots" CONTENT="INDEX,FOLLOW">
-  <link href="test/legacy.css" rel="stylesheet">
+  <link href="dist/legacy.css" rel="stylesheet">
 </head>
 <body>
       <div class="utility hide-on-print">

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ joexn.io
   <META NAME="Description" CONTENT="The getting started page for the Legacy Framework. This page contains the code you need to get started creating your own website.">
   <META NAME="Keywords" CONTENT="Legacy, Framework, Getting, Started, joexn, LegacyFramework.com">
   <META NAME="Robots" CONTENT="INDEX,FOLLOW">
-  <link href="dist/legacy.css" rel="stylesheet">
+  <link href="test/legacy.css" rel="stylesheet">
 </head>
 <body>
       <div class="utility hide-on-print">

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   },
   "homepage": "https://github.com/joexn/LegacyFramework#readme",
   "devDependencies": {
+    "browser-sync": "^2.13.0",
     "gulp": "^3.9.1",
+    "gulp-autoprefixer": "^3.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "legacyframework",
+  "version": "4.0.0",
+  "description": "Legacy is a modern, lightweight CSS framework.",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/joexn/LegacyFramework.git"
+  },
+  "author": "joexn",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/joexn/LegacyFramework/issues"
+  },
+  "homepage": "https://github.com/joexn/LegacyFramework#readme",
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-sass": "^2.3.2"
+  }
+}


### PR DESCRIPTION
I figured the project could benefit from a modern & extensible build suite. Gulp is almost the de facto  build system for web these days, so that is what I used. It will help people new to the project get up-and-running as the configuration for the build tools are already completed - it now takes only two commands to have Legacy build from source (assuming you have node installed). Most open source web projects provide a similar build system. It also makes build setup very easy and should significantly speed up testing and modification of the source as all changes are immediately compiled and rendered in connected local browsers. 

I've included an npm package for built tool dependencies, and configured gulp to process Legacy's sass, auto-prefix and minify the source, and inject it into all connected browsers via browsersync. I have also updated the readme to reflect the new tools. 

Hit me up on the slack channel if you have any questions/suggestions! 
