### PR TITLE
Fix comment issue

### DIFF
--- a/src/legacy.sass
+++ b/src/legacy.sass
@@ -1,4 +1,4 @@
-//
+/*
 
 
   Welcome to Legacy 4.0
@@ -15,7 +15,7 @@
     Thanks for using Legacy.
 
 
-
+*/
 
 
 


### PR DESCRIPTION
It's actually valid as-is, but GitHub's syntax highlighting doesn't think so (see nathos/sass-textmate-bundle#91). This is a workaround to get online syntax highlighting working. 
