### PR TITLE
Add .gitignore for gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
If node_modules is ignored in the dev and latest branches, it will be kept intact when checking out gh-pages. It then needs to be ignored in gh-pages too so that it won't be checked in there.
